### PR TITLE
Was input events fix

### DIFF
--- a/src/window/backends/web/visitor.rs
+++ b/src/window/backends/web/visitor.rs
@@ -54,6 +54,11 @@ impl WebVisitor {
             .set_attribute("id", "canvas")
             .unwrap();
 
+        canvas
+            .unchecked_ref::<Element>()
+            .set_attribute("tabindex", "1")
+            .unwrap();
+
         AsRef::<Node>::as_ref(&body)
             .append_child(canvas.as_ref())
             .unwrap();

--- a/src/window/backends/web/visitor.rs
+++ b/src/window/backends/web/visitor.rs
@@ -108,8 +108,8 @@ impl WebVisitor {
                 let rect = canvas.get_bounding_client_rect();
 
                 let position = (
-                    v.layer_x() as f32 - rect.x() as f32,
-                    height - v.layer_y() as f32 + rect.y() as f32,
+                    v.client_x() as f32 - rect.x() as f32,
+                    height - v.client_y() as f32 + rect.y() as f32,
                 );
 
                 let evt = Event::InputDevice(InputEvent::MouseMoved { position });


### PR DESCRIPTION
### Problem
Some window events handled wrong when wasm is the build target.

1. `MouseEvent` doesn't have `layer_x` and `layer_y` properties, so instead of getting mouse position we got errors.
2. `KeyboardEvent` binded to the canvas doesn't triggers when canvas element is out of focus.

### Fix
1. Use `client_x` and `client_y` properties instead.
2. Add `tabindex` attribute to the canvas to focus by mouse click. Maybe we should add more complex focus detection, something like canvas must be focused when mouse is over it.

Thank you.