### PR TITLE
Web: Catch keyboard events in the window and redirect them to canvas.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ features = [
     'XmlHttpRequestResponseType',
     'Response',
     'EventTarget',
+    'Event',
     'MouseEvent',
     'KeyboardEvent',
     'UiEvent'

--- a/src/window/backends/web/visitor.rs
+++ b/src/window/backends/web/visitor.rs
@@ -130,13 +130,14 @@ impl WebVisitor {
             let clone = events.clone();
             Closure::wrap(Box::new(move |v: KeyboardEvent| {
                 if let Some(key) = types::from_virtual_key_code(&v.key()) {
+                    v.prevent_default();
                     let evt = Event::InputDevice(InputEvent::KeyboardPressed { key });
                     clone.lock().unwrap().push(evt);
                 }
             }) as Box<FnMut(_)>)
         };
 
-        canvas
+        window
             .add_event_listener_with_callback("keydown", on_key_down.as_ref().unchecked_ref())
             .unwrap();
 
@@ -144,13 +145,14 @@ impl WebVisitor {
             let clone = events.clone();
             Closure::wrap(Box::new(move |v: KeyboardEvent| {
                 if let Some(key) = types::from_virtual_key_code(&v.key()) {
+                    v.prevent_default();
                     let evt = Event::InputDevice(InputEvent::KeyboardReleased { key });
                     clone.lock().unwrap().push(evt);
                 }
             }) as Box<FnMut(_)>)
         };
 
-        canvas
+        window
             .add_event_listener_with_callback("keyup", on_key_up.as_ref().unchecked_ref())
             .unwrap();
 
@@ -162,7 +164,7 @@ impl WebVisitor {
             }) as Box<FnMut(_)>)
         };
 
-        canvas
+        window
             .add_event_listener_with_callback("focus", on_focus.as_ref().unchecked_ref())
             .unwrap();
 
@@ -174,7 +176,7 @@ impl WebVisitor {
             }) as Box<FnMut(_)>)
         };
 
-        canvas
+        window
             .add_event_listener_with_callback("blur", on_lost_focus.as_ref().unchecked_ref())
             .unwrap();
 


### PR DESCRIPTION
This Pr provides a simple workaround for the issues mentioned in #71. The user could have keyboard events after getting window focus immediately.